### PR TITLE
add 301redirect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,15 @@
 class ApplicationController < ActionController::Base
+
+  #herokuapp.comから独自ドメインへリダイレクト
+  before_filter :ensure_domain
+  FQDN = 'www.medipra.net'
+
+  # redirect correct server from herokuapp domain for SEO
+  def ensure_domain
+  return unless /\.herokuapp.com/ =~ request.host
+  
+  # 主にlocalテスト用の対策80と443以外でアクセスされた場合ポート番号をURLに含める 
+  port = ":#{request.port}" unless [80, 443].include?(request.port)
+  redirect_to "#{request.protocol}#{FQDN}#{port}#{request.path}", status: :moved_permanently
+  end
 end


### PR DESCRIPTION
# why
www.medipra.netとmedipra.herokuapp.comの二つが存在し、SEO的によくない（重複とみなされる）ため３０１リダイレクトを設定

# what
301リダイレクトを設置